### PR TITLE
maxWidth / maxHeight

### DIFF
--- a/routes/uploadManager.js
+++ b/routes/uploadManager.js
@@ -13,8 +13,8 @@ var options = {
     inlineFileTypes:  /\.(gif|jpe?g|png)$/i,
     imageTypes:  /\.(gif|jpe?g|png)$/i,
     imageVersions: {
-        width:  80,
-        height: 80
+        maxWidth:  80,
+        maxHeight: 80
     },
     accessControl: {
         allowOrigin: '*',


### PR DESCRIPTION
Due to this commit, the `imageVersions` structure has changed.
https://github.com/arvindr21/blueimp-file-upload-expressjs/commit/448a766ddf4dc659f633ea5c3a7bf0a68067ada5
